### PR TITLE
Aspects as wrappers 

### DIFF
--- a/aspects.go
+++ b/aspects.go
@@ -1,0 +1,72 @@
+package restful
+
+import (
+	"log"
+	"net/http"
+	"net/http/pprof"
+	"strconv"
+	"strings"
+
+	"github.com/abhiunc/go-restful"
+)
+
+//Creates Logger before RouteFunction is executed via wrapping
+func LoggingAspect(fn restful.RouteFunction) restful.RouteFunction {
+	return func(r *restful.Request, w *restful.Response) {
+		log.Printf("[WebserviceLogging] {%s}, \n%s  \n%s  \n%s  \n%s  \n%s\n",
+			strings.Split(r.Request.RemoteAddr, ":")[0],
+			"[Method]: "+r.Request.Method,
+			"[URL]: "+r.Request.URL.String(),
+			"[Protocol]: "+r.Request.Proto,
+			"[Status]: "+strconv.Itoa(w.StatusCode()),
+			"[Length]: "+strconv.Itoa(w.ContentLength()),
+		)
+		fn(r, w)
+	}
+}
+
+//Creates Authentication at RouteFunction level.
+func AuthAspect(fn restful.RouteFunction) restful.RouteFunction {
+	return func(r *restful.Request, w *restful.Response) {
+		token := r.HeaderParameter("X-AUTH-TOKEN")
+		if token == "" {
+			http.Error(w, "missing auth token", http.StatusUnauthorized)
+			return
+		}
+		//Write own authentication mechanism here.
+		fn(r, w)
+	}
+}
+
+//runs Index profiling on wrapped RouteFunction
+func IndexHandler(fn restful.RouteFunction) restful.RouteFunction {
+	return func(r *restful.Request, w *restful.Response) {
+		pprof.Index(w.ResponseWriter, r.Request)
+		fn(r, w)
+	}
+}
+
+//Trace profiler on wrapper RouteFunction
+func TraceHandler(fn restful.RouteFunction) restful.RouteFunction {
+	return func(r *restful.Request, w *restful.Response) {
+		pprof.Trace(w.ResponseWriter, r.Request)
+		fn(r, w)
+	}
+}
+
+//General Profiling on RouteFunction
+func ProfileHandler(fn restful.RouteFunction) restful.RouteFunction {
+	return func(r *restful.Request, w *restful.Response) {
+		pprof.Profile(w.ResponseWriter, r.Request)
+		fn(r, w)
+	}
+}
+
+//Symbol Profiling on RouteFunction
+func SymbolHandler(fn restful.RouteFunction) restful.RouteFunction {
+	return func(r *restful.Request, w *restful.Response) {
+		//c := pprof.Symbol(w.ResponseWriter, r.Request)
+		log.Printf(" ")
+		fn(r, w)
+	}
+}

--- a/examples/restful-authaspect.go
+++ b/examples/restful-authaspect.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/abhiunc/go-restful"
+)
+
+// This example shows the minimal code needed to get a restful.WebService working.
+//
+// GET http://localhost:8080/hello
+
+func main() {
+	ws := new(restful.WebService)
+	ws.Route(ws.GET("/hello").To(AuthAspect(hello))) //wrap aspect around RouteFunction
+	restful.Add(ws)
+	http.ListenAndServe(":8000", nil)
+}
+
+func hello(req *restful.Request, resp *restful.Response) {
+	io.WriteString(resp, "world")
+}


### PR DESCRIPTION
Going down the hierarchy of execution, I found that the easiest area to apply principles of AOP was the RouteFunction. You can wrap the generic RouteFunction to execute code before it reaches the end of the Route. Any function that accepts (*Request, *Response) is a generic RouteFunction and can be used with this type of wrapping.
