### PR TITLE
Simplified versioning example

### DIFF
--- a/entity_accessors_test.go
+++ b/entity_accessors_test.go
@@ -42,28 +42,53 @@ func TestKeyValueEncoding(t *testing.T) {
 		Author        string
 		PublishedYear int
 	}
+
 	kv := new(keyvalue)
-	RegisterEntityAccessor("application/kv", kv)
+	kv2 := new(keyvalue)
+
+	RegisterEntityAccessor("application/vnd.my.company+v1+kv", kv)
+
+	// registering entity accessor for v2
+	RegisterEntityAccessor("application/vnd.my.company+v2+kv", kv2)
+
 	b := Book{"Singing for Dummies", "john doe", 2015}
 
 	// Write
 	httpWriter := httptest.NewRecorder()
+
+	// SWITCH VERSION
 	//								Accept									Produces
-	resp := Response{httpWriter, "application/kv,*/*;q=0.8", []string{"application/kv"}, 0, 0, true, nil}
+	resp := Response{httpWriter, "application/vnd.my.company+v2+kv,*/*;q=0.8", []string{"application/vnd.my.company+v2+kv"}, 0, 0, true, nil}
+	// SWITCH VERSION
+
 	resp.WriteEntity(b)
+
+
 	t.Log(string(httpWriter.Body.Bytes()))
+
 	if !kv.writeCalled {
-		t.Error("Write never called")
+		t.Error("Write never called - v1")
+	}
+	if !kv2.writeCalled {
+		t.Error("Write never called - v2")
 	}
 
 	// Read
 	bodyReader := bytes.NewReader(httpWriter.Body.Bytes())
 	httpRequest, _ := http.NewRequest("GET", "/test", bodyReader)
-	httpRequest.Header.Set("Content-Type", "application/kv; charset=UTF-8")
+
+	// SWITCH VERSION
+	httpRequest.Header.Set("Content-Type", "application/vnd.my.company+v2+kv; charset=UTF-8")
+	// SWITCH VERSION
+
 	request := NewRequest(httpRequest)
 	var bb Book
 	request.ReadEntity(&bb)
+
 	if !kv.readCalled {
-		t.Error("Read never called")
+		t.Error("Read never called - v1")
+	}
+	if !kv2.readCalled {
+		t.Error("Read never called - v2")
 	}
 }

--- a/examples/versioning-test.go
+++ b/examples/versioning-test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"github.com/emicklei/go-restful"
+	"net/http"
+	"reflect"
+)
+
+// simple struct for registering new entity accessor
+type keyvalue struct {
+	readCalled bool
+	writeCalled bool
+}
+
+// generic read function
+func (kv *keyvalue) Read(req *restful.Request, v interface{}) error {
+	kv.readCalled = true
+	return nil
+}
+
+// generic write function
+func (kv *keyvalue) Write(resp *restful.Response, status int, v interface{}) error {
+	t := reflect.TypeOf(v)
+	rv := reflect.ValueOf(v)
+	for ix := 0; ix < t.NumField(); ix++ {
+		sf := t.Field(ix)
+		io.WriteString(resp, sf.Name)
+		io.WriteString(resp, "=")
+		io.WriteString(resp, fmt.Sprintf("%v\n", rv.Field(ix).Interface()))
+	}
+	kv.writeCalled = true
+	return nil
+}
+
+func main() {
+	kv := new(keyvalue)
+
+	// create new entity accessor for application/test+v1 since it is not standard
+	restful.RegisterEntityAccessor("application/test+v1", kv)
+
+	// spin up a new webservice
+	ws := new(restful.WebService)
+
+	// create path to /testing
+	ws.Path("/testing").
+		Consumes(restful.MIME_JSON). 	// standard json input
+		Produces(restful.MIME_JSON)		// standard json output
+
+	ws.Route(ws.GET("/").To(hello).			// route GET at root of /testing to hello function
+		Consumes("application/test+v1").	// consumes our custom accept header
+		Produces("application/test+v1"))	// produces our custom accept header
+
+	restful.Add(ws)
+	http.ListenAndServe(":8080", nil)
+}
+
+// checks the Accept header of request
+func hello(req *restful.Request, resp *restful.Response) {
+	// fmt.Println(req.Request.Header.Get(restful.HEADER_Accept))
+
+	// print VERSION 1 if header == application/test+v2
+	if(req.Request.Header.Get(restful.HEADER_Accept) == "application/test+v1") {
+		fmt.Println("VERSION 1")
+	} else { // print DEFAULT if header == "" or "*/*"
+		fmt.Println("DEFAULT")
+	}
+
+	// any other header will be unaccepted!
+}


### PR DESCRIPTION
I added another keyvalue pair to simulate a different version for this test API.

the "//SWITCH VERSION" tags designate the lines where you can alternate the version of the API, forcing the read and write checks to also change accordingly when run. Both versions service the same exact data, but exist in different entity accessors. I tried to make this example as simple as possible for easier reading.
